### PR TITLE
Refactor Empty Line Around X Logic

### DIFF
--- a/__tests__/make-sure-content-has-empty-lines-added-before-and-after.test.ts
+++ b/__tests__/make-sure-content-has-empty-lines-added-before-and-after.test.ts
@@ -170,7 +170,7 @@ const testCases: EmptyStringBeforeAndAfterTestCase[] = [
   },
   {
     startOfContent: 124, // start of the 2nd code block: "`"
-    endOfContent: 175, // end of the 2nd code block: "`"
+    endOfContent: 175, // end of the 2nd code block: "\n"
     testName: 'Fenced code blocks that are in a blockquote have the proper empty line added',
     before: dedent`
       # Make sure that code blocks in blockquotes are accounted for correctly

--- a/__tests__/make-sure-content-has-empty-lines-added-before-and-after.test.ts
+++ b/__tests__/make-sure-content-has-empty-lines-added-before-and-after.test.ts
@@ -1,0 +1,133 @@
+import {makeSureContentHasEmptyLinesAddedBeforeAndAfter} from '../src/utils/strings';
+import dedent from 'ts-dedent';
+
+type EmptyStringBeforeAndAfterTestCase = {
+  testName: string,
+  isForBlockquote: boolean,
+  startOfContent: number,
+  endOfContent: number
+  before: string,
+  after: string,
+}
+
+const testCases: EmptyStringBeforeAndAfterTestCase[] = [
+  {
+    testName: 'Content with no empty line before or after it should have one added before and after',
+    isForBlockquote: false,
+    startOfContent: 9,
+    endOfContent: 26,
+    before: dedent`
+      # Header
+      Text content here
+      ## Other Header
+    `,
+    after: dedent`
+      # Header
+      ${''}
+      Text content here
+      ${''}
+      ## Other Header
+    `,
+  },
+  {
+    testName: 'Content with multiple empty lines before it should have one added before and after',
+    isForBlockquote: false,
+    startOfContent: 12,
+    endOfContent: 29,
+    before: dedent`
+      # Header
+      ${''}
+      ${''}
+      ${''}
+      Text content here
+      ${''}
+      ## Other Header
+    `,
+    after: dedent`
+      # Header
+      ${''}
+      Text content here
+      ${''}
+      ## Other Header
+    `,
+  },
+  {
+    testName: 'Content at the start of the file should not get an empty line added before it',
+    isForBlockquote: false,
+    startOfContent: 0,
+    endOfContent: 17,
+    before: dedent`
+      Text content here
+      ${''}
+      ## Other Header
+    `,
+    after: dedent`
+      Text content here
+      ${''}
+      ## Other Header
+    `,
+  },
+  {
+    testName: 'Content at the end of the file should not get an empty line added after it',
+    isForBlockquote: false,
+    startOfContent: 9,
+    endOfContent: 26,
+    before: dedent`
+      # Header
+      Text content here
+    `,
+    after: dedent`
+      # Header
+      ${''}
+      Text content here
+    `,
+  },
+  {
+    testName: 'Content in blockquote has en empty line added before and after it',
+    isForBlockquote: false,
+    startOfContent: 11,
+    endOfContent: 28,
+    before: dedent`
+      # Header
+      > Text content here
+      More unrelated content here
+    `,
+    after: dedent`
+      # Header
+      ${''}
+      > Text content here
+      ${''}
+      More unrelated content here
+    `,
+  },
+  {
+    testName: 'Content in blockquote that is surrounded by more content in the same blockquote does not end the blockquote',
+    isForBlockquote: false,
+    startOfContent: 64,
+    endOfContent: 81,
+    before: dedent`
+      # Header
+      > Content prior to content to put empty lines around
+      > Text content here
+      > Content after content to put empty lines around
+    `,
+    after: dedent`
+      # Header
+      > Content prior to content to put empty lines around
+      >
+      > Text content here
+      >
+      > Content after content to put empty lines around
+    `,
+  },
+];
+
+
+describe('Make Sure Content Has Empty Lines Added Before and After', () => {
+  for (const testCase of testCases) {
+    it(testCase.testName, () => {
+      console.log(testCase.testName, testCase.before.indexOf('Text content here'));
+      expect(makeSureContentHasEmptyLinesAddedBeforeAndAfter(testCase.before, testCase.startOfContent, testCase.endOfContent, testCase.isForBlockquote)).toStrictEqual(testCase.after);
+    });
+  }
+});

--- a/__tests__/make-sure-content-has-empty-lines-added-before-and-after.test.ts
+++ b/__tests__/make-sure-content-has-empty-lines-added-before-and-after.test.ts
@@ -3,7 +3,6 @@ import dedent from 'ts-dedent';
 
 type EmptyStringBeforeAndAfterTestCase = {
   testName: string,
-  isForBlockquote: boolean,
   startOfContent: number,
   endOfContent: number
   before: string,
@@ -13,7 +12,6 @@ type EmptyStringBeforeAndAfterTestCase = {
 const testCases: EmptyStringBeforeAndAfterTestCase[] = [
   {
     testName: 'Content with no empty line before or after it should have one added before and after',
-    isForBlockquote: false,
     startOfContent: 9,
     endOfContent: 26,
     before: dedent`
@@ -32,7 +30,6 @@ const testCases: EmptyStringBeforeAndAfterTestCase[] = [
   {
     testName: 'Content with multiple empty lines before it should have one added before and after',
     isForBlockquote: false,
-    startOfContent: 12,
     endOfContent: 29,
     before: dedent`
       # Header
@@ -53,7 +50,6 @@ const testCases: EmptyStringBeforeAndAfterTestCase[] = [
   },
   {
     testName: 'Content at the start of the file should not get an empty line added before it',
-    isForBlockquote: false,
     startOfContent: 0,
     endOfContent: 17,
     before: dedent`
@@ -69,7 +65,6 @@ const testCases: EmptyStringBeforeAndAfterTestCase[] = [
   },
   {
     testName: 'Content at the end of the file should not get an empty line added after it',
-    isForBlockquote: false,
     startOfContent: 9,
     endOfContent: 26,
     before: dedent`
@@ -84,7 +79,6 @@ const testCases: EmptyStringBeforeAndAfterTestCase[] = [
   },
   {
     testName: 'Content in blockquote has en empty line added before and after it',
-    isForBlockquote: false,
     startOfContent: 11,
     endOfContent: 28,
     before: dedent`
@@ -102,7 +96,6 @@ const testCases: EmptyStringBeforeAndAfterTestCase[] = [
   },
   {
     testName: 'Content in blockquote that is surrounded by more content in the same blockquote does not end the blockquote',
-    isForBlockquote: false,
     startOfContent: 64,
     endOfContent: 81,
     before: dedent`
@@ -120,14 +113,110 @@ const testCases: EmptyStringBeforeAndAfterTestCase[] = [
       > Content after content to put empty lines around
     `,
   },
+  {
+    testName: 'A table in a blockquote or callout should have a blank line added before and after the table',
+    startOfContent: 24, // start of the table header: "|"
+    endOfContent: 206, // end of the table "\n"
+    before: dedent`
+      > Table in blockquote
+      > | Column 1 | Column 2 | Column 3 |
+      > |----------|----------|----------|
+      > | foo      | bar      | blob     |
+      > | baz      | qux      | trust    |
+      > | quux     | quuz     | glob     |
+      ${''}
+      More content here
+    `,
+    after: dedent`
+      > Table in blockquote
+      >
+      > | Column 1 | Column 2 | Column 3 |
+      > |----------|----------|----------|
+      > | foo      | bar      | blob     |
+      > | baz      | qux      | trust    |
+      > | quux     | quuz     | glob     |
+      ${''}
+      More content here
+    `,
+  },
+  {
+    testName: 'A table in a nested blockquote or callout should have a blank line added before and after the table',
+    startOfContent: 59, // start of the table header: "|"
+    endOfContent: 249, // end of the table "\n"
+    before: dedent`
+      More content here
+      ${''}
+      > Table doubly nested in blockquote
+      > > | Column 1 | Column 2 | Column 3 |
+      > > |----------|----------|----------|
+      > > | foo      | bar      | blob     |
+      > > | baz      | qux      | trust    |
+      > > | quux     | quuz     | glob     |
+      More content here
+    `,
+    after: dedent`
+      More content here
+      ${''}
+      > Table doubly nested in blockquote
+      >
+      > > | Column 1 | Column 2 | Column 3 |
+      > > |----------|----------|----------|
+      > > | foo      | bar      | blob     |
+      > > | baz      | qux      | trust    |
+      > > | quux     | quuz     | glob     |
+      ${''}
+      More content here
+    `,
+  },
+  {
+    startOfContent: 124, // start of the 2nd code block: "`"
+    endOfContent: 175, // end of the 2nd code block: "`"
+    testName: 'Fenced code blocks that are in a blockquote have the proper empty line added',
+    before: dedent`
+      # Make sure that code blocks in blockquotes are accounted for correctly
+      > \`\`\`js
+      > var text = 'this is some text';
+      > \`\`\`
+      >
+      > \`\`\`js
+      > var other text = 'this is more text';
+      > \`\`\`
+      ${''}
+      **Note that the blanks blockquote lines added do not have whitespace after them**
+      ${''}
+      # Doubly nested code block
+      ${''}
+      > > \`\`\`js
+      > > var other text = 'this is more text';
+      > > \`\`\`
+    `,
+    after: dedent`
+      # Make sure that code blocks in blockquotes are accounted for correctly
+      > \`\`\`js
+      > var text = 'this is some text';
+      > \`\`\`
+      >
+      > \`\`\`js
+      > var other text = 'this is more text';
+      > \`\`\`
+      ${''}
+      **Note that the blanks blockquote lines added do not have whitespace after them**
+      ${''}
+      # Doubly nested code block
+      ${''}
+      > > \`\`\`js
+      > > var other text = 'this is more text';
+      > > \`\`\`
+    `,
+  },
 ];
 
 
 describe('Make Sure Content Has Empty Lines Added Before and After', () => {
   for (const testCase of testCases) {
     it(testCase.testName, () => {
-      console.log(testCase.testName, testCase.before.indexOf('Text content here'));
-      expect(makeSureContentHasEmptyLinesAddedBeforeAndAfter(testCase.before, testCase.startOfContent, testCase.endOfContent, testCase.isForBlockquote)).toStrictEqual(testCase.after);
+      // console.log(testCase.testName, testCase.before.indexOf('Text content here')); // helpful for adding new tests
+      expect(makeSureContentHasEmptyLinesAddedBeforeAndAfter(testCase.before, testCase.startOfContent, testCase.endOfContent)).toStrictEqual(testCase.after);
     });
   }
 });

--- a/src/rules/empty-line-around-code-fences.ts
+++ b/src/rules/empty-line-around-code-fences.ts
@@ -79,7 +79,7 @@ export default class EmptyLineAroundCodeFences extends RuleBuilder<EmptyLineArou
         `,
         after: dedent`
           # Make sure that code blocks in blockquotes are accounted for correctly
-          >
+
           > \`\`\`js
           > var text = 'this is some text';
           > \`\`\`
@@ -87,13 +87,11 @@ export default class EmptyLineAroundCodeFences extends RuleBuilder<EmptyLineArou
           > \`\`\`js
           > var other text = 'this is more text';
           > \`\`\`
-          >
           ${''}
           **Note that the blanks blockquote lines added do not have whitespace after them**
           ${''}
           # Doubly nested code block
           ${''}
-          > >
           > > \`\`\`js
           > > var other text = 'this is more text';
           > > \`\`\`

--- a/src/rules/empty-line-around-math-block.ts
+++ b/src/rules/empty-line-around-math-block.ts
@@ -112,12 +112,11 @@ export default class EmptyLineAroundMathBlock extends RuleBuilder<EmptyLineAroun
           > $$
           > \\boldsymbol{a}=\\begin{bmatrix}a_x \\\\ a_y\\end{bmatrix}
           > $$
-          >
           ${''}
           More content here
           ${''}
           > Math block doubly nested in blockquote
-          > >
+          >
           > > $$
           > > \\boldsymbol{a}=\\begin{bmatrix}a_x \\\\ a_y\\end{bmatrix}
           > > $$

--- a/src/rules/empty-line-around-tables.ts
+++ b/src/rules/empty-line-around-tables.ts
@@ -135,12 +135,11 @@ export default class EmptyLineAroundTables extends RuleBuilder<EmptyLineAroundTa
           > | foo      | bar      | blob     |
           > | baz      | qux      | trust    |
           > | quux     | quuz     | glob     |
-          >
           ${''}
           More content here
           ${''}
           > Table doubly nested in blockquote
-          > >
+          >
           > > | Column 1 | Column 2 | Column 3 |
           > > |----------|----------|----------|
           > > | foo      | bar      | blob     |

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -436,7 +436,13 @@ export function ensureEmptyLinesAroundMathBlock(text: string, numberOfDollarSign
 export function ensureEmptyLinesAroundBlockquotes(text: string): string {
   const positions: Position[] = getPositions(MDAstTypes.Blockquote, text);
   for (const position of positions) {
-    text = makeSureContentHasEmptyLinesAddedBeforeAndAfter(text, position.start.offset, position.end.offset, true);
+    // make sure to shift end to the next new line character just in case blocquotes are nested which can cause changes to move content out of the original position expected
+    let endIndex = position.end.offset;
+    while (endIndex < text.length - 1 && text.charAt(endIndex) !== '\n') {
+      endIndex++;
+    }
+
+    text = makeSureContentHasEmptyLinesAddedBeforeAndAfter(text, position.start.offset, endIndex);
   }
 
   return text;

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -69,7 +69,7 @@ export function ensureEmptyLinesAroundTables(text: string): string {
   }
 
   for (const table of tableMatches) {
-    let start = text.indexOf(table);
+    let start = text.indexOf(table.trimStart());
     const end = start + table.length;
     if (table.trim().startsWith('>')) {
       while (text.charAt(start).trim() === '' || text.charAt(start) === '>') {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,5 +1,3 @@
-import {escapeRegExp} from './regex';
-
 /**
  * Inserts a string at the given position in a string.
  * @param {string} str - The string to insert into

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -47,6 +47,184 @@ function textMatches(expectedText: string, actualText: string, requireSameTraili
   return actualText.match(new RegExp('^' + escapeRegExp(expectedText) + '( |\\t)*$', 'm')) != null;
 }
 
+function getStartOfLineWhitespaceOrBlockquoteLevel(text: string, startPosition: number): [string, number] {
+  if (startPosition === 0) {
+    return ['', 0];
+  }
+
+  let startOfLine = '';
+  let index = startPosition;
+  while (index >= 0) {
+    const char = text.charAt(index);
+    if (char === '\n') {
+      break;
+    } else if (char.trim() === '' || char === '>') {
+      startOfLine = char + startOfLine;
+    } else {
+      startOfLine = '';
+    }
+
+    index--;
+  }
+
+  return [startOfLine, index];
+}
+
+function getEmptyLine(startOfLine: string, priorLine: string = ''): string {
+  const [priorLineStart] = getStartOfLineWhitespaceOrBlockquoteLevel(priorLine, priorLine.length);
+
+  // let emptyLine = '\n';
+
+  // if (priorLineStart === startOfLine) {
+  //   emptyLine += startOfLine.trim();
+  // } else if (priorLineStart.trim() !== '') {
+  //   emptyLine += startOfLine.substring(0, startOfLine.lastIndexOf('>') - 1);
+  // }
+
+  return '\n' + priorLineStart.trim();
+}
+
+function makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFile(text: string, startOfContent: number): string {
+  if (startOfContent === 0) {
+    return text;
+  }
+
+  let index = startOfContent;
+  let startOfNewContent = startOfContent;
+  while (index >= 0) {
+    const currentChar = text.charAt(index);
+    if (currentChar.trim() !== '') {
+      break; // if non-whitespace is encountered, then the line has content
+    } else if (currentChar === '\n') {
+      startOfNewContent = index;
+    }
+    index--;
+  }
+
+  if (index < 0 || startOfNewContent === 0) {
+    return text.substring(startOfContent + 1);
+  }
+
+  return text.substring(0, startOfNewContent) + '\n' + text.substring(startOfContent);
+}
+
+function makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFileForBlockquote(text: string, startOfLine: string, startOfContent: number): string {
+  if (startOfContent === 0) {
+    return text;
+  }
+
+  const nestingLevel = startOfLine.split('>').length - 1;
+  let index = startOfContent;
+  let startOfNewContent = startOfContent;
+  let lineNestingLevel = 0;
+  while (index >= 0) {
+    const currentChar = text.charAt(index);
+    if (currentChar.trim() !== '' && currentChar !== '>') {
+      // TODO: determine if bracket name is right
+      break; // if non-whitespace, non-lt-bracket is encountered, then the line has content
+    } else if (currentChar === '>') {
+      lineNestingLevel++;
+    } else if (currentChar === '\n') {
+      if (lineNestingLevel === 0 || lineNestingLevel === nestingLevel || (lineNestingLevel + 1) === nestingLevel) {
+        startOfNewContent = index;
+        lineNestingLevel = 0;
+      } else {
+        break;
+      }
+    }
+    index--;
+  }
+
+  if (index < 0 || startOfNewContent === 0) {
+    return text.substring(startOfContent + 1);
+  }
+
+  const indexOfLastNewLine = text.lastIndexOf('\n', startOfNewContent - 1);
+  let priorLine = '';
+  if (indexOfLastNewLine === -1) {
+    priorLine = text.substring(0, startOfNewContent);
+  } else {
+    priorLine = text.substring(indexOfLastNewLine, startOfNewContent);
+  }
+
+  return text.substring(0, startOfNewContent) + getEmptyLine(startOfLine, priorLine) + text.substring(startOfContent);
+}
+
+function makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFile(text: string, endOfContent: number): string {
+  if (endOfContent === (text.length - 1)) {
+    return text;
+  }
+
+  let index = endOfContent;
+  let endOfNewContent = endOfContent;
+  let isFirstNewLine = true;
+  while (index < text.length) {
+    const currentChar = text.charAt(index);
+    if (currentChar.trim() !== '') {
+      break; // if non-whitespace is encountered, then the line has content
+    } else if (currentChar === '\n') {
+      if (isFirstNewLine) {
+        isFirstNewLine = false;
+      } else {
+        endOfNewContent = index;
+      }
+    }
+    index++;
+  }
+
+  if (index === text.length || endOfNewContent === text.length - 1) {
+    return text.substring(0, endOfContent);
+  }
+
+  return text.substring(0, endOfContent) + '\n' + text.substring(endOfNewContent);
+}
+
+function makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote(text: string, startOfLine: string, endOfContent: number): string {
+  if (endOfContent === (text.length - 1)) {
+    return text;
+  }
+
+  const nestingLevel = startOfLine.split('>').length - 1;
+  let index = endOfContent;
+  let endOfNewContent = endOfContent;
+  let isFirstNewLine = true;
+  let lineNestingLevel = 0;
+  while (index < text.length) {
+    const currentChar = text.charAt(index);
+    if (currentChar.trim() !== '' && currentChar !== '>') {
+      break; // if non-whitespace is encountered, then the line has content
+    } else if (currentChar === '>') {
+      lineNestingLevel++;
+    } else if (currentChar === '\n') {
+      if (lineNestingLevel === 0 || lineNestingLevel === nestingLevel || (lineNestingLevel + 1) === nestingLevel) {
+        lineNestingLevel = 0;
+        if (isFirstNewLine) {
+          isFirstNewLine = false;
+        } else {
+          endOfNewContent = index;
+        }
+      } else {
+        break;
+      }
+    }
+    index++;
+  }
+
+  if (index === text.length || endOfNewContent === text.length - 1) {
+    return text.substring(0, endOfContent);
+  }
+
+  const indexOfSecondNewLineAfterContent = text.indexOf('\n', endOfNewContent + 1);
+  let nextLine = '';
+  if (indexOfSecondNewLineAfterContent === -1) {
+    nextLine = text.substring(endOfNewContent);
+  } else {
+    nextLine = text.substring(indexOfSecondNewLineAfterContent);
+  }
+
+  return text.substring(0, endOfContent) + getEmptyLine(startOfLine, nextLine) + text.substring(endOfNewContent);
+}
+
 /**
  * Makes sure that the specified content has an empty line around it so long as it does not start or end a file.
  * @param {string} text - The entire file's contents
@@ -56,67 +234,18 @@ function textMatches(expectedText: string, actualText: string, requireSameTraili
  * @return {string} The new file contents after the empty lines have been added
  */
 export function makeSureContentHasEmptyLinesAddedBeforeAndAfter(text: string, start: number, end: number, isForBlockquotes: boolean = false): string {
-  const content = text.substring(start, end);
-  let startOfLine = '';
-  let contentPriorToContent = text.substring(0, start);
-  if (contentPriorToContent.length > 0) {
-    const contentLinesPriorToContent = contentPriorToContent.split('\n');
-    startOfLine = contentLinesPriorToContent[contentLinesPriorToContent.length - 1] ?? '';
-    startOfLine = startOfLine.trimEnd();
+  const [startOfLine, startOfLineIndex] = getStartOfLineWhitespaceOrBlockquoteLevel(text, start);
 
+  // handle content in blockquotes
+  if (startOfLine.trim() !== '') {
+    const newText = makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote(text, startOfLine, end);
 
-    let numberOfIndexesToRemove = 0;
-    while (contentLinesPriorToContent.length - (2 + numberOfIndexesToRemove) >= 0) {
-      const lineContent = contentLinesPriorToContent[contentLinesPriorToContent.length - (2 + numberOfIndexesToRemove)];
-      if (!textMatches(startOfLine, lineContent) && (!isForBlockquotes || !textMatches('', lineContent, true))) {
-        break;
-      }
-
-      numberOfIndexesToRemove++;
-    }
-
-    contentLinesPriorToContent.splice(contentLinesPriorToContent.length - (1 + numberOfIndexesToRemove), numberOfIndexesToRemove);
-
-    if (contentLinesPriorToContent.length > 1) {
-      if ((isForBlockquotes && contentLinesPriorToContent[contentLinesPriorToContent.length - 2].match(/^> ?.*$/m)) ||
-      (!isForBlockquotes && !textMatches(startOfLine, contentLinesPriorToContent[contentLinesPriorToContent.length - 2]))) {
-        contentLinesPriorToContent.splice(contentLinesPriorToContent.length - 1, 0, startOfLine);
-      } else if (!textMatches('', contentLinesPriorToContent[contentLinesPriorToContent.length - 2], true)) {
-        contentLinesPriorToContent.splice(contentLinesPriorToContent.length - 1, 0, '');
-      }
-    }
-
-    contentPriorToContent = contentLinesPriorToContent.join('\n');
+    return makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFileForBlockquote(newText, startOfLine, startOfLineIndex);
   }
 
-  let contentAfterContent = text.substring(end);
-  if (contentAfterContent.length > 0) {
-    const contentLinesAfterBlock = contentAfterContent.split('\n');
-    let numberOfIndexesToRemove = 0;
-    while (numberOfIndexesToRemove + 1 < contentLinesAfterBlock.length) {
-      const lineContent = contentLinesAfterBlock[1+numberOfIndexesToRemove];
-      if (!textMatches(startOfLine, lineContent) && (!isForBlockquotes || !textMatches('', lineContent, true))) {
-        break;
-      }
+  const newText = makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFile(text, end);
 
-      numberOfIndexesToRemove++;
-    }
-
-    contentLinesAfterBlock.splice(1, numberOfIndexesToRemove);
-
-    if (contentLinesAfterBlock.length > 1) {
-      if ((isForBlockquotes && contentLinesAfterBlock[1].match(/^> ?.*$/m)) ||
-      (!isForBlockquotes && !textMatches(startOfLine, contentLinesAfterBlock[1]))) {
-        contentLinesAfterBlock.splice(1, 0, startOfLine);
-      } else if (isForBlockquotes && !textMatches('', contentLinesAfterBlock[1])) {
-        contentLinesAfterBlock.splice(1, 0, '');
-      }
-    }
-
-    contentAfterContent = contentLinesAfterBlock.join('\n');
-  }
-
-  return contentPriorToContent + content + contentAfterContent;
+  return makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFile(newText, startOfLineIndex);
 }
 
 // from https://stackoverflow.com/a/52171480/8353749


### PR DESCRIPTION
This makes the empty line around content logic more robust and reusable.

Changes Made:
- Converted the logic over to get the start of the line ignoring non-whitespace and greater than characters (>)
- Made sure the logic would decide which empty line value to use when blockquotes were involved to make things more uniform
- Updated several examples to show the change in logic